### PR TITLE
error correction Invalid value: Not in range 0..1114111

### DIFF
--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -63,7 +63,7 @@ class PostgreSQLFormat {
     final iterator = RuneIterator(fmtString);
 
     iterator.moveNext();
-    while (iterator.current != null) {
+    while (iterator.current != null && iterator.current != -1) {
       if (currentPtr == null) {
         if (iterator.current == _atSignCodeUnit) {
           currentPtr =


### PR DESCRIPTION
Invalid value: Not in range 0..1114111, inclusive: -1 #0      StringB
uffer.writeCharCode (dart:core-patch/string_buffer_patch.dart:76:9)
PostgreSQLFormat.substitute (package:postgres/src/substituter.dart:83:29


Dart VM version: 2.8.0-dev.17.0.flutter-1402e8e1a4 (be) (Thu Mar 26 13:15:18 2020 +0000) on "windows_x64"